### PR TITLE
docs: fix stale counts in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ lib/
 ├── 04-vps-harden.sh      # SSH, fail2ban, auditd, compliance
 ├── 05-prerequisites.sh   # apt packages, build deps
 ├── 06-package-managers.sh # Rust, uv, bun, Go, mise, Docker
+├── 06b-repo-files.sh     # Clone titan repo early for REPO_FILES
 ├── 07-tools-python-js.sh # Python/JS tools, n8n, playwright
 ├── 08-tools-letta.sh     # Ollama, Letta, better-ccflare, billing proxy
 ├── 09-tools-rust-go.sh   # Cargo crates, Go tools, binary installs
@@ -25,6 +26,7 @@ lib/
 ├── 16-shell-integration.sh # PATH exports, bashrc integration
 └── 17-finalize.sh        # Summary, compliance check, tmux cleanup
 ```
+*(19 fragments total)*
 
 ## Build & Test
 

--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ Desktop only: `maim`, `xdotool`.
 | Skills | 15 | Trimmed, self-contained (vibesec, cli-tools, modern-python, security-scan, etc.) |
 | Plugins (MCP) | 6–8 | hookify, code-review, skill-creator, playwright, episodic-memory, claude-subconscious (if Letta), cozempic, semgrep (if token) |
 | Hook events | 14 | PreToolUse (safety), PostToolUse (audit), SessionStart (memory), etc. |
-| Conditional rules | 6 | Trigger on file type (Python, shell, terraform, docker, security) |
+| Conditional rules | 7 | Trigger on file type (Python, shell, terraform, docker, security, skill-authoring, memory) |
 | Slash commands | 12 | `/ship`, `/scan`, `/review`, `/workspace-init`, `/remember`, etc. |
 | Built-in agents | 3 | researcher (Haiku), planner (Opus), reviewer (Sonnet) |
-| On-demand agent slots | 5 | Load from agent-stash library via `agt` CLI |
+| On-demand agent slots | 10 | Load from agent-stash library via `agt` CLI |
 | Auto-patcher | 1 | `cc-patch-thinking` — shows thinking blocks inline, auto-patches after CC updates |
 
 ---
@@ -482,7 +482,7 @@ Titan pulls from and integrates with 60+ open-source projects across the AI deve
 | [obra/superpowers](https://github.com/obra/superpowers) | TDD, debugging, brainstorming, verification, and planning skills + marketplace |
 | [trailofbits/skills](https://github.com/trailofbits/skills) | Modern Python tooling skill (uv, ruff, ty) |
 | [BehiSecc/VibeSec-Skill](https://github.com/BehiSecc/VibeSec-Skill) | Secure web application development skill |
-| [SutanuNandigrami/agent-stash](https://github.com/SutanuNandigrami/agent-stash) | 30 ready-made agents for on-demand slot loading |
+| [SutanuNandigrami/agent-stash](https://github.com/SutanuNandigrami/agent-stash) | 185 ready-made agents for on-demand slot loading |
 | *hookify* (official plugin) | Visual hook configuration and management |
 | *code-review* (official plugin) | PR review subagent with structured review |
 | *skill-creator* (official plugin) | Interactive skill authoring |


### PR DESCRIPTION
## Summary
- Agent slots: 5 → 10
- Conditional rules: 6 → 7 (skill-authoring was missing)
- Agent stash: 30 → 185
- CONTRIBUTING.md: add missing `06b-repo-files.sh` fragment, note 19 total fragments

🤖 Generated with [Claude Code](https://claude.com/claude-code)