### PR TITLE
fix: tmux wrapper emits empty arg breaking desktop mode

### DIFF
--- a/lib/03-vps-reexec.sh
+++ b/lib/03-vps-reexec.sh
@@ -75,7 +75,9 @@ if [[ -z "${TMUX:-}" ]] && [[ "${TITAN_TMUX:-}" != "1" ]]; then
     _TMUX_WRAPPER=$(mktemp /tmp/titan-tmux-XXXXXX.sh)
     {
       printf 'TITAN_TMUX=1 bash %q' "$0"
-      printf ' %q' "${_ORIG_ARGS[@]+"${_ORIG_ARGS[@]}"}"
+      if [[ ${#_ORIG_ARGS[@]} -gt 0 ]]; then
+        printf ' %q' "${_ORIG_ARGS[@]}"
+      fi
       # Carry forward interactively-resolved values not present in _ORIG_ARGS
       if [[ -n "${TAILSCALE_KEY:-}" ]]; then
         printf ' --tailscale-key %q' "$TAILSCALE_KEY"

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -286,7 +286,9 @@ if [[ -z "${TMUX:-}" ]] && [[ "${TITAN_TMUX:-}" != "1" ]]; then
     _TMUX_WRAPPER=$(mktemp /tmp/titan-tmux-XXXXXX.sh)
     {
       printf 'TITAN_TMUX=1 bash %q' "$0"
-      printf ' %q' "${_ORIG_ARGS[@]+"${_ORIG_ARGS[@]}"}"
+      if [[ ${#_ORIG_ARGS[@]} -gt 0 ]]; then
+        printf ' %q' "${_ORIG_ARGS[@]}"
+      fi
       # Carry forward interactively-resolved values not present in _ORIG_ARGS
       if [[ -n "${TAILSCALE_KEY:-}" ]]; then
         printf ' --tailscale-key %q' "$TAILSCALE_KEY"


### PR DESCRIPTION
## Summary
- `bash <(curl ...)` with no CLI args caused the tmux wrapper to emit an empty `''` argument
- The CLI parser rejected it: `Unknown option: ` → immediate exit before install started
- Root cause: `printf ' %q' "${_ORIG_ARGS[@]+"${_ORIG_ARGS[@]}"}"` expands to `printf ' %q' ""` when the array is empty
- Fix: guard with `[[ ${#_ORIG_ARGS[@]} -gt 0 ]]`

## Why this only affects desktop mode
VPS mode always passes explicit args (`--mode vps --claude-user ...`), so `_ORIG_ARGS` is never empty. Desktop mode with no args (interactive prompts) hits this path.

## Test plan
- [x] `just test` — 71/71 pass
- [x] `just build` — 2801 lines, build-check clean
- [x] `shellcheck lib/03-vps-reexec.sh` — no new warnings
- [x] Simulated empty `_ORIG_ARGS` — wrapper output has no empty arg
- [x] `gitleaks detect` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)