### PR TITLE
fix: ufw/iptables fallback + gpg hang + tailscale wait

### DIFF
--- a/lib/16-finalize.sh
+++ b/lib/16-finalize.sh
@@ -99,7 +99,13 @@ fi
 # Public port 22 deletion and sshd restart happen LAST (after all output)
 # so the current SSH session stays alive through the entire install.
 if [[ "$INSTALL_MODE" == "vps" && "${_TAILSCALE_FAILED:-}" != "true" ]]; then
-  command -v ufw &>/dev/null && sudo ufw allow in on tailscale0 || true
+  # Allow traffic on tailscale interface — ufw on Hetzner, iptables on Oracle/others
+  if command -v ufw &>/dev/null; then
+    sudo ufw allow in on tailscale0 || true
+  elif command -v iptables &>/dev/null; then
+    sudo iptables -C INPUT -i tailscale0 -j ACCEPT 2>/dev/null ||
+      sudo iptables -I INPUT 1 -i tailscale0 -j ACCEPT 2>/dev/null || true
+  fi
   COMPLIANCE_OUT=$(sudo /usr/local/bin/compliance_check.sh 2>/dev/null || true)
 elif [[ "$INSTALL_MODE" == "vps" ]]; then
   warn "SSH lockdown skipped — Tailscale not connected. Run tailscale up manually, then:"
@@ -220,8 +226,14 @@ if [[ "$INSTALL_MODE" == "vps" && "${_TAILSCALE_FAILED:-}" != "true" ]]; then
   if [[ -z "${TS_IP:-}" ]]; then
     warn "Tailscale IP empty — skipping SSH lockdown (run manually after tailscale up)"
   else
-    sudo ufw delete allow 22/tcp || true
-    sudo ufw delete allow OpenSSH 2>/dev/null || true
+    # Remove public SSH access — ufw on Hetzner, iptables on Oracle/others
+    if command -v ufw &>/dev/null; then
+      sudo ufw delete allow 22/tcp || true
+      sudo ufw delete allow OpenSSH 2>/dev/null || true
+    elif command -v iptables &>/dev/null; then
+      sudo iptables -D INPUT -p tcp --dport 22 -j ACCEPT 2>/dev/null || true
+      sudo iptables -D INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT 2>/dev/null || true
+    fi
     sudo sed -i '/^#\?ListenAddress /d' /etc/ssh/sshd_config
     echo "ListenAddress $TS_IP" | sudo tee -a /etc/ssh/sshd_config >/dev/null
     # Validate config before restart to avoid SSH lockout

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -3301,7 +3301,13 @@ fi
 # Public port 22 deletion and sshd restart happen LAST (after all output)
 # so the current SSH session stays alive through the entire install.
 if [[ "$INSTALL_MODE" == "vps" && "${_TAILSCALE_FAILED:-}" != "true" ]]; then
-  command -v ufw &>/dev/null && sudo ufw allow in on tailscale0 || true
+  # Allow traffic on tailscale interface — ufw on Hetzner, iptables on Oracle/others
+  if command -v ufw &>/dev/null; then
+    sudo ufw allow in on tailscale0 || true
+  elif command -v iptables &>/dev/null; then
+    sudo iptables -C INPUT -i tailscale0 -j ACCEPT 2>/dev/null ||
+      sudo iptables -I INPUT 1 -i tailscale0 -j ACCEPT 2>/dev/null || true
+  fi
   COMPLIANCE_OUT=$(sudo /usr/local/bin/compliance_check.sh 2>/dev/null || true)
 elif [[ "$INSTALL_MODE" == "vps" ]]; then
   warn "SSH lockdown skipped — Tailscale not connected. Run tailscale up manually, then:"
@@ -3422,8 +3428,14 @@ if [[ "$INSTALL_MODE" == "vps" && "${_TAILSCALE_FAILED:-}" != "true" ]]; then
   if [[ -z "${TS_IP:-}" ]]; then
     warn "Tailscale IP empty — skipping SSH lockdown (run manually after tailscale up)"
   else
-    sudo ufw delete allow 22/tcp || true
-    sudo ufw delete allow OpenSSH 2>/dev/null || true
+    # Remove public SSH access — ufw on Hetzner, iptables on Oracle/others
+    if command -v ufw &>/dev/null; then
+      sudo ufw delete allow 22/tcp || true
+      sudo ufw delete allow OpenSSH 2>/dev/null || true
+    elif command -v iptables &>/dev/null; then
+      sudo iptables -D INPUT -p tcp --dport 22 -j ACCEPT 2>/dev/null || true
+      sudo iptables -D INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT 2>/dev/null || true
+    fi
     sudo sed -i '/^#\?ListenAddress /d' /etc/ssh/sshd_config
     echo "ListenAddress $TS_IP" | sudo tee -a /etc/ssh/sshd_config >/dev/null
     # Validate config before restart to avoid SSH lockout


### PR DESCRIPTION
## Summary
Fixes from Oracle Cloud ARM testing:

- **ufw missing**: Oracle Cloud Ubuntu uses iptables, not ufw. Bare `sudo ufw` crashes under set -e. Added iptables fallback for tailscale0 allow and port 22 lockdown
- **gpg --dearmor hang**: piping curl/wget to gpg hangs when download fails. Download to temp file first
- **tailscaled wait**: wait for service to start after install before running tailscale up
- **docker GID**: check /proc/PID/status for actual GID in systemd user manager
- **apt lock**: wait for dpkg lock before apt operations (unattended-upgrades on boot)

Tested on both ARM (iptables) and x86 (ufw) live VPS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)