### PR TITLE
fix: build ccflare dashboard before CLI on ARM64

### DIFF
--- a/lib/08-tools-letta.sh
+++ b/lib/08-tools-letta.sh
@@ -201,7 +201,10 @@ PYEOF
       mkdir -p "$HOME/.bun/bin"
       # NOTE: cd is required — `bun --cwd` does not propagate CWD to shell subprocesses
       # in the build script, which uses relative paths like ../../packages/
-      if run_q bun install --cwd "$_BCF_SRC" && (cd "$_BCF_SRC/apps/cli" && run_q bun run build); then
+      # Dashboard must be built BEFORE CLI — CLI embeds dashboard assets at compile time
+      if run_q bun install --cwd "$_BCF_SRC" &&
+        run_q bun run --cwd "$_BCF_SRC" build:dashboard &&
+        (cd "$_BCF_SRC/apps/cli" && run_q bun run build); then
         _BCF_DIST="$_BCF_SRC/apps/cli/dist/better-ccflare"
         if [[ -f "$_BCF_DIST" ]]; then
           mkdir -p "$HOME/.bun/bin" "$HOME/.local/bin"

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -1544,7 +1544,10 @@ PYEOF
       mkdir -p "$HOME/.bun/bin"
       # NOTE: cd is required — `bun --cwd` does not propagate CWD to shell subprocesses
       # in the build script, which uses relative paths like ../../packages/
-      if run_q bun install --cwd "$_BCF_SRC" && (cd "$_BCF_SRC/apps/cli" && run_q bun run build); then
+      # Dashboard must be built BEFORE CLI — CLI embeds dashboard assets at compile time
+      if run_q bun install --cwd "$_BCF_SRC" &&
+        run_q bun run --cwd "$_BCF_SRC" build:dashboard &&
+        (cd "$_BCF_SRC/apps/cli" && run_q bun run build); then
         _BCF_DIST="$_BCF_SRC/apps/cli/dist/better-ccflare"
         if [[ -f "$_BCF_DIST" ]]; then
           mkdir -p "$HOME/.bun/bin" "$HOME/.local/bin"


### PR DESCRIPTION
## Summary
- Add `bun run build:dashboard` step before CLI compilation in the better-ccflare source build
- Without this, the compiled ARM64 binary reports "Dashboard assets not found" and disables the web UI
- The upstream `prepublishOnly` script does this automatically, but our source build path skipped it

## Verified on
- **Oracle ARM** (`claude-1.magpie-lake.ts.net`): dashboard returns HTTP 200 at `/` and `/dashboard`
- **Local x86**: unaffected (uses npm pre-built binary which already has dashboard)

## Test plan
- [x] `just build && just test` — 168/168 pass
- [x] `gitleaks detect` — no leaks
- [x] Live Oracle ARM: rebuilt binary (107MB) with embedded dashboard assets
- [x] Dashboard accessible at `http://localhost:9090/` and `/dashboard` (tested on alt port)

🤖 Generated with [Claude Code](https://claude.com/claude-code)