### PR TITLE
fix: close ARM64 E2E gaps — crash.journal, tailscale serve, cloud SSH

### DIFF
--- a/lib/07-tools-python-js.sh
+++ b/lib/07-tools-python-js.sh
@@ -155,6 +155,8 @@ elif command -v docker &>/dev/null; then
   if [ "$(stat -c %u "$HOME/.n8n" 2>/dev/null)" != "1000" ]; then
     sudo chown -R 1000:1000 "$HOME/.n8n" 2>/dev/null || chown -R 1000:1000 "$HOME/.n8n" 2>/dev/null || true
   fi
+  # Clean crash artifacts from previous failed runs (causes "Last session crashed" loop)
+  rm -f "$HOME/.n8n/crash.journal" 2>/dev/null || true
 
   # Create systemd user service for n8n
   # Use detached docker + Type=oneshot — attached docker clients get SIGKILL'd

--- a/lib/16-finalize.sh
+++ b/lib/16-finalize.sh
@@ -62,6 +62,8 @@ if [[ "$INSTALL_MODE" == "vps" ]]; then
     TS_HOSTNAME=$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//')
 
     # ── tailscale serve — expose local services on Tailscale network ───────
+    # Reset stale serve rules from previous runs (hostname may have changed)
+    tailscale serve reset 2>/dev/null || true
     # tailscale serve is a proxy config — backend doesn't need to be running yet
     if command -v docker &>/dev/null; then
       tailscale serve --bg --https=5678 http://localhost:5678 2>/dev/null &&
@@ -235,6 +237,12 @@ if [[ "$INSTALL_MODE" == "vps" && "${_TAILSCALE_FAILED:-}" != "true" ]]; then
       sudo iptables -D INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT 2>/dev/null || true
     fi
     sudo sed -i '/^#\?ListenAddress /d' /etc/ssh/sshd_config
+    # Remove ListenAddress from cloud drop-ins (Oracle 60-cloudimg-settings.conf etc.)
+    # These take precedence over sshd_config and can override our Tailscale-only binding
+    for _dropin in /etc/ssh/sshd_config.d/*.conf; do
+      [[ -f "$_dropin" ]] || continue
+      sudo sed -i '/^#\?ListenAddress /d' "$_dropin"
+    done
     echo "ListenAddress $TS_IP" | sudo tee -a /etc/ssh/sshd_config >/dev/null
     # Validate config before restart to avoid SSH lockout
     if sudo sshd -t 2>/dev/null; then

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -1307,6 +1307,8 @@ elif command -v docker &>/dev/null; then
   if [ "$(stat -c %u "$HOME/.n8n" 2>/dev/null)" != "1000" ]; then
     sudo chown -R 1000:1000 "$HOME/.n8n" 2>/dev/null || chown -R 1000:1000 "$HOME/.n8n" 2>/dev/null || true
   fi
+  # Clean crash artifacts from previous failed runs (causes "Last session crashed" loop)
+  rm -f "$HOME/.n8n/crash.journal" 2>/dev/null || true
 
   # Create systemd user service for n8n
   # Use detached docker + Type=oneshot — attached docker clients get SIGKILL'd
@@ -3264,6 +3266,8 @@ if [[ "$INSTALL_MODE" == "vps" ]]; then
     TS_HOSTNAME=$(tailscale status --json 2>/dev/null | jq -r '.Self.DNSName // empty' | sed 's/\.$//')
 
     # ── tailscale serve — expose local services on Tailscale network ───────
+    # Reset stale serve rules from previous runs (hostname may have changed)
+    tailscale serve reset 2>/dev/null || true
     # tailscale serve is a proxy config — backend doesn't need to be running yet
     if command -v docker &>/dev/null; then
       tailscale serve --bg --https=5678 http://localhost:5678 2>/dev/null &&
@@ -3437,6 +3441,12 @@ if [[ "$INSTALL_MODE" == "vps" && "${_TAILSCALE_FAILED:-}" != "true" ]]; then
       sudo iptables -D INPUT -p tcp -m state --state NEW --dport 22 -j ACCEPT 2>/dev/null || true
     fi
     sudo sed -i '/^#\?ListenAddress /d' /etc/ssh/sshd_config
+    # Remove ListenAddress from cloud drop-ins (Oracle 60-cloudimg-settings.conf etc.)
+    # These take precedence over sshd_config and can override our Tailscale-only binding
+    for _dropin in /etc/ssh/sshd_config.d/*.conf; do
+      [[ -f "$_dropin" ]] || continue
+      sudo sed -i '/^#\?ListenAddress /d' "$_dropin"
+    done
     echo "ListenAddress $TS_IP" | sudo tee -a /etc/ssh/sshd_config >/dev/null
     # Validate config before restart to avoid SSH lockout
     if sudo sshd -t 2>/dev/null; then


### PR DESCRIPTION
## Summary
- Clean `~/.n8n/crash.journal` before n8n service start (prevents "Last session crashed" crash loop on re-run)
- Reset `tailscale serve` rules before reconfiguring (clears stale hostname bindings from previous installs)
- Remove `ListenAddress` from cloud provider SSH drop-ins (Oracle `60-cloudimg-settings.conf` can override Tailscale-only binding)

## Context
These 3 gaps were identified during the ARM64 E2E audit — the main fixes (PR #47, #48) were correct but these edge cases affect re-runs and Oracle Cloud specifically.

## Test plan
- [x] `just build && just test` — 168/168 pass
- [x] `gitleaks detect` — no leaks
- [ ] Full re-run on Oracle ARM VPS (will test after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)