### PR TITLE
feat: integrate vexp-cli context engine (ADR-031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ For full documentation see [README.md](README.md) and [USER_GUIDE.md](USER_GUIDE
 
 ---
 
+### v3.21 — vexp-cli context engine integration (ADR-030)
+
+**vexp-cli — local-first context engine for AI coding agents:**
+- Installed via `bun install -g vexp-cli` with `trustedDependencies` for postinstall binary download
+- Auto-configured as global MCP server in `settings.json` (stdio transport — CC spawns on demand)
+- Uses tree-sitter AST parsing + dependency graphs + skeleton context for ~65% token reduction
+- 11 MCP tools: `run_pipeline`, `get_context_capsule`, `get_impact_graph`, `search_logic_flow`, etc.
+- Free tier: 2,000 nodes, 8 calls/day, 7 tools — works out of box, no license key needed
+- Supports 30 languages (TypeScript, Python, Go, Rust, Bash, HCL, etc.)
+- Binary verification: warns if vexp-core Rust binary missing after postinstall
+
+**New CLI flag:**
+- `--no-vexp` — skip vexp-cli install
+- `--minimal` now also skips vexp-cli
+
+**Architecture:**
+- ADR-030: stdio transport over HTTP+SSE — no daemon, no port, no systemd service
+- mcpServers key NOT in TITAN_MANAGED_BLOCKS — user-added MCP servers preserved across re-runs
+- 170 bats tests (2 new for vexp-cli integration)
+
+---
+
 ### v3.20 — ARM64 docker reliability, live testing overhaul, 168 tests
 
 - Replaced ccstatusline with claude-lens: quota pace tracking, zero-config, no bun dependency (ADR-030)

--- a/bin/agt
+++ b/bin/agt
@@ -21,35 +21,47 @@ INDEX="$STASH_DIR/index.tsv"
 
 # ─── Colors ────────────────────────────────────────────────────────────────────
 if [[ -t 1 ]]; then
-  GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'
-  RED='\033[0;31m'; BOLD='\033[1m'; NC='\033[0m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  CYAN='\033[0;36m'
+  RED='\033[0;31m'
+  BOLD='\033[1m'
+  NC='\033[0m'
 else
-  GREEN=''; YELLOW=''; CYAN=''; RED=''; BOLD=''; NC=''
+  GREEN=''
+  YELLOW=''
+  CYAN=''
+  RED=''
+  BOLD=''
+  NC=''
 fi
 
 # ─── Helpers ───────────────────────────────────────────────────────────────────
-die()  { echo -e "${RED}error:${NC} $*" >&2; exit 1; }
+die() {
+  echo -e "${RED}error:${NC} $*" >&2
+  exit 1
+}
 info() { echo -e "${CYAN}info:${NC}  $*"; }
-ok()   { echo -e "${GREEN}ok:${NC}    $*"; }
+ok() { echo -e "${GREEN}ok:${NC}    $*"; }
 warn() { echo -e "${YELLOW}warn:${NC}  $*"; }
 
 require_stash() {
   [[ -d "$STASH_AGENTS" ]] || die "Stash not found: $STASH_AGENTS — run: agt refresh"
-  [[ -f "$INDEX" ]]        || die "Index missing — run: agt build-index"
+  [[ -f "$INDEX" ]] || die "Index missing — run: agt build-index"
 }
 
 ensure_loaded_dir() {
   mkdir -p "$LOADED_DIR"
   [[ -f "$MANIFEST" ]] || touch "$MANIFEST"
-  [[ -f "$LOCK" ]]     || touch "$LOCK"
+  [[ -f "$LOCK" ]] || touch "$LOCK"
 }
 
 slot_model() {
   case "$1" in
-    slot-1|slot-2|slot-3|slot-6|slot-7|slot-8) echo "haiku" ;;
-    slot-4|slot-9)          echo "sonnet" ;;
-    slot-5|slot-10)         echo "opus" ;;
-    *)                     echo "unknown" ;;
+    slot-1 | slot-2 | slot-3 | slot-6 | slot-7 | slot-8) echo "haiku" ;;
+    slot-4 | slot-9) echo "sonnet" ;;
+    slot-5 | slot-10) echo "opus" ;;
+    *) echo "unknown" ;;
   esac
 }
 
@@ -99,10 +111,14 @@ cmd_load() {
   local agent_name='' slot_override=''
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --slot)   shift; [[ $# -gt 0 ]] || die "--slot requires a number"; slot_override="slot-$1" ;;
+      --slot)
+        shift
+        [[ $# -gt 0 ]] || die "--slot requires a number"
+        slot_override="slot-$1"
+        ;;
       --slot=*) slot_override="slot-${1#--slot=}" ;;
-      -*)       die "Unknown option: $1" ;;
-      *)        agent_name="$1" ;;
+      -*) die "Unknown option: $1" ;;
+      *) agent_name="$1" ;;
     esac
     shift
   done
@@ -118,7 +134,7 @@ cmd_load() {
       die "Agent not found: $agent_name — try: agt search $agent_name"
     fi
     echo "Agent '$agent_name' not found. Did you mean:"
-    while IFS= read -r m; do echo "  $m"; done <<< "$matches"
+    while IFS= read -r m; do echo "  $m"; done <<<"$matches"
     exit 1
   fi
 
@@ -136,7 +152,7 @@ cmd_load() {
     local slot=''
     if [[ -n "$slot_override" ]]; then
       local num="${slot_override#slot-}"
-      if [[ "$num" =~ ^[0-9]+$ ]] && (( num >= 1 && num <= SLOT_COUNT )); then
+      if [[ "$num" =~ ^[0-9]+$ ]] && ((num >= 1 && num <= SLOT_COUNT)); then
         if [[ -f "$LOADED_DIR/${slot_override}.md" ]]; then
           local occ
           occ=$(grep "^${slot_override}	" "$MANIFEST" 2>/dev/null | cut -f2 || echo "unknown")
@@ -165,7 +181,7 @@ cmd_load() {
       warn "Agent prefers '$model_hint' but $slot uses '$slot_m'"
       case "$model_hint" in
         sonnet) warn "Consider: agt load $agent_name --slot 4" ;;
-        opus)   warn "Consider: agt load $agent_name --slot 5" ;;
+        opus) warn "Consider: agt load $agent_name --slot 5" ;;
       esac
     fi
 
@@ -175,10 +191,10 @@ cmd_load() {
     ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
     # remove stale entry for this slot
     if [[ -s "$MANIFEST" ]]; then
-      grep -v "^${slot}	" "$MANIFEST" > "${MANIFEST}.tmp" || true
+      grep -v "^${slot}	" "$MANIFEST" >"${MANIFEST}.tmp" || true
       mv "${MANIFEST}.tmp" "$MANIFEST"
     fi
-    printf '%s\t%s\t%s\n' "$slot" "$agent_name" "$ts" >> "$MANIFEST"
+    printf '%s\t%s\t%s\n' "$slot" "$agent_name" "$ts" >>"$MANIFEST"
 
     ok "Loaded '$agent_name' → $slot [${slot_m}]"
     echo "  Invoke in Claude Code with subagent_type: $slot"
@@ -199,7 +215,7 @@ cmd_unload() {
       for i in $(seq 1 "$SLOT_COUNT"); do
         if [[ -f "$LOADED_DIR/slot-${i}.md" ]]; then
           rm -f "$LOADED_DIR/slot-${i}.md"
-          (( count++ )) || true
+          ((count++)) || true
         fi
       done
       truncate -s 0 "$MANIFEST"
@@ -222,7 +238,7 @@ cmd_unload() {
       warn "$slot was already empty"
     fi
     if [[ -s "$MANIFEST" ]]; then
-      grep -v "^${slot}	" "$MANIFEST" > "${MANIFEST}.tmp" || true
+      grep -v "^${slot}	" "$MANIFEST" >"${MANIFEST}.tmp" || true
       mv "${MANIFEST}.tmp" "$MANIFEST"
     fi
   ) 200>"$LOCK"
@@ -267,18 +283,18 @@ cmd_info() {
 cmd_build_index() {
   [[ -d "$STASH_AGENTS" ]] || die "Stash agents dir not found: $STASH_AGENTS"
   local tmp="${INDEX}.tmp"
-  printf 'name\ttags\tdescription\tmodel-hint\n' > "$tmp"
+  printf 'name\ttags\tdescription\tmodel-hint\n' >"$tmp"
   local count=0
 
   while IFS= read -r -d '' md_file; do
     local name tags description model_hint
     name=$(fm_field "$md_file" "name")
-    [[ -n "$name" ]] || continue   # skip files without name frontmatter
+    [[ -n "$name" ]] || continue # skip files without name frontmatter
     tags=$(fm_field "$md_file" "tags")
     description=$(fm_field "$md_file" "description")
     model_hint=$(fm_field "$md_file" "model-hint")
-    printf '%s\t%s\t%s\t%s\n' "$name" "${tags:-}" "${description:-}" "${model_hint:-haiku}" >> "$tmp"
-    (( count++ )) || true
+    printf '%s\t%s\t%s\t%s\n' "$name" "${tags:-}" "${description:-}" "${model_hint:-haiku}" >>"$tmp"
+    ((count++)) || true
   done < <(find "$STASH_AGENTS" -maxdepth 1 -name "*.md" -print0 | sort -z)
 
   mv "$tmp" "$INDEX"
@@ -310,15 +326,16 @@ cmd_refresh() {
   exit 0
 }
 
-cmd="$1"; shift
+cmd="$1"
+shift
 case "$cmd" in
-  search)      cmd_search "$@" ;;
-  list)        cmd_list ;;
-  load)        cmd_load "$@" ;;
-  unload)      cmd_unload "$@" ;;
-  status)      cmd_status ;;
-  info)        cmd_info "$@" ;;
-  refresh)     cmd_refresh ;;
+  search) cmd_search "$@" ;;
+  list) cmd_list ;;
+  load) cmd_load "$@" ;;
+  unload) cmd_unload "$@" ;;
+  status) cmd_status ;;
+  info) cmd_info "$@" ;;
+  refresh) cmd_refresh ;;
   build-index) cmd_build_index ;;
   *) die "Unknown command: $cmd — run 'agt' for help" ;;
 esac

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -183,3 +183,10 @@ Immutable once written. New decisions get new numbers; old ones get "Superseded"
 **Context**: lib/12-plugins-install.sh and lib/13-plugins-config.sh shared an if/fi block across the fragment boundary. This was a maintenance landmine — editing one file could break the other without any indication.
 **Decision**: Merge into single `lib/12-plugins.sh`. Renumber subsequent fragments (14→13, 15→14, 16→15, 17→16). Total fragments: 19→18.
 **Consequences**: All if/fi blocks are self-contained within a single file. No cross-fragment dependencies. Slightly larger file (~160 lines) but much easier to maintain.
+
+
+## ADR-031: vexp-cli as global MCP server via stdio transport (2026-03-23)
+**Status**: Accepted
+**Context**: vexp-cli provides tree-sitter AST parsing, dependency graphs, and skeleton context for token-efficient code understanding. Ships 11 MCP tools (run_pipeline, get_context_capsule, get_impact_graph, etc.). Two transport options: stdio (on-demand, CC manages lifecycle) and HTTP+SSE (persistent daemon on port 7821).
+**Decision**: Install via `bun install -g vexp-cli` (uses optional deps `@vexp/core-linux-x64` etc. for platform binary — no postinstall). Configure as global MCP server in settings.json using stdio transport (`vexp mcp`). Injected via jq post-merge. Skip with `--minimal` or `--no-vexp`. mcpServers key NOT in TITAN_MANAGED_BLOCKS — user-added MCP servers preserved across re-runs.
+**Consequences**: Zero-touch UX — CC spawns `vexp mcp` on demand, no systemd service or port management. Trade-off: ~2s cold start per session for Rust daemon startup. ARM64 supported via `@vexp/core-linux-arm64` optional dep; binary verification warns if missing.

--- a/lib/00-header.sh
+++ b/lib/00-header.sh
@@ -40,4 +40,4 @@ fi
 # ║  from patrickjaja.github.io via sudo.                            ║
 # ╚══════════════════════════════════════════════════════════════════╝
 
-SCRIPT_VERSION="v3.20"
+SCRIPT_VERSION="v3.21"

--- a/lib/02-cli.sh
+++ b/lib/02-cli.sh
@@ -21,6 +21,7 @@ OLLAMA_SKIP=false
 LETTA_CTRL_SKIP=false
 LETTA_CTRL_PORT=8284
 COZEMPIC_SKIP=false
+VEXP_SKIP=false
 FORCE_UPDATES=false
 MINIMAL=false
 
@@ -51,6 +52,7 @@ Options:
   --letta-ctrl-skip        Skip LettaCtrl GUI (default: install if Letta is installed)
   --letta-ctrl-port PORT   LettaCtrl server port (default: 8284)
   --no-cozempic            Skip cozempic install (context bloat cleaner)
+  --no-vexp                Skip vexp-cli install (context engine)
 
   --force-updates          Force upgrade all tools (uv, bun, cargo, go, binaries)
   --version                Show script version
@@ -189,6 +191,10 @@ while [[ $# -gt 0 ]]; do
       COZEMPIC_SKIP=true
       shift
       ;;
+    --no-vexp)
+      VEXP_SKIP=true
+      shift
+      ;;
     --force-updates)
       FORCE_UPDATES=true
       shift
@@ -203,6 +209,7 @@ while [[ $# -gt 0 ]]; do
       OLLAMA_SKIP=true
       COZEMPIC_SKIP=true
       LETTA_CTRL_SKIP=true
+      VEXP_SKIP=true
       shift
       ;;
     --secrets-file)

--- a/lib/06-package-managers.sh
+++ b/lib/06-package-managers.sh
@@ -14,7 +14,8 @@ else
     if command -v cargo &>/dev/null; then
       ok "cargo installed: $(cargo --version)"
     else
-      fail "cargo install failed"; exit 1
+      fail "cargo install failed"
+      exit 1
     fi
   fi
   # Ensure cargo binaries are on PATH for the rest of this script (idempotent)
@@ -31,7 +32,8 @@ else
     if command -v uv &>/dev/null; then
       ok "uv installed: $(uv --version)"
     else
-      fail "uv install failed"; exit 1
+      fail "uv install failed"
+      exit 1
     fi
   fi
   # Ensure uv/uvx binaries are on PATH for the rest of this script

--- a/lib/07-tools-python-js.sh
+++ b/lib/07-tools-python-js.sh
@@ -111,6 +111,22 @@ fi
 command -v gemini &>/dev/null && ok "gemini-cli (exists)" || { run_q bun install -g @google/gemini-cli && ok "gemini-cli" || warn "gemini-cli"; }
 command -v mmdc &>/dev/null && ok "mermaid-cli (exists)" || { run_q bun install -g @mermaid-js/mermaid-cli && ok "mermaid-cli" || warn "mermaid-cli"; }
 
+# vexp-cli — local-first context engine for AI coding agents (tree-sitter + dependency graph)
+# Uses optional deps (@vexp/core-linux-x64 etc.) for platform-specific Rust binary — no postinstall needed
+if ! $VEXP_SKIP && ! $MINIMAL; then
+  if bun pm ls -g 2>/dev/null | grep -q "vexp-cli"; then
+    ok "vexp-cli (exists)"
+  else
+    run_q bun install -g vexp-cli && ok "vexp-cli" || warn "vexp-cli (install manually: bun install -g vexp-cli)"
+  fi
+  # Verify vexp-core platform binary was installed via optional deps
+  if command -v vexp &>/dev/null && vexp version &>/dev/null; then
+    ok "vexp-core binary ($(vexp version 2>&1 | grep 'core:' | sed 's/.*: //' || echo 'ok'))"
+  elif bun pm ls -g 2>/dev/null | grep -q "vexp-cli"; then
+    warn "vexp-core binary missing — try: bun install -g @vexp/core-linux-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"
+  fi
+fi
+
 # playwright — browser automation and E2E testing
 # Ensure node is on PATH (mise shims may not be sourced in non-interactive context)
 command -v node &>/dev/null || export PATH="$HOME/.local/share/mise/shims:$PATH"

--- a/lib/09-tools-rust-go.sh
+++ b/lib/09-tools-rust-go.sh
@@ -424,7 +424,7 @@ if ! command -v gcloud &>/dev/null; then
   # Download key to temp file first — piping to gpg --dearmor hangs if curl fails
   _GPG_TMP="$WORKDIR/gcloud.gpg"
   if curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg -o "$_GPG_TMP" 2>/dev/null; then
-    sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg < "$_GPG_TMP" 2>/dev/null || true
+    sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg <"$_GPG_TMP" 2>/dev/null || true
   fi
   echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" |
     sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
@@ -436,7 +436,7 @@ else ok "gcloud (exists)"; fi
 if ! command -v terraform &>/dev/null; then
   _GPG_TMP="$WORKDIR/hashicorp.gpg"
   if wget -qO "$_GPG_TMP" https://apt.releases.hashicorp.com/gpg 2>/dev/null; then
-    sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg < "$_GPG_TMP" 2>/dev/null || true
+    sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg <"$_GPG_TMP" 2>/dev/null || true
   fi
   echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
   apt_update --force && sudo apt-get install -y -qq terraform packer &&
@@ -473,7 +473,7 @@ else ok "duckdb (exists)"; fi
 if ! command -v trivy &>/dev/null; then
   _GPG_TMP="$WORKDIR/trivy.gpg"
   if wget -qO "$_GPG_TMP" https://aquasecurity.github.io/trivy-repo/deb/public.key 2>/dev/null; then
-    sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg < "$_GPG_TMP" 2>/dev/null || true
+    sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg <"$_GPG_TMP" 2>/dev/null || true
   fi
   echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list >/dev/null
   apt_update --force && sudo apt-get install -y -qq trivy &&
@@ -483,7 +483,7 @@ else
   if ! grep -q 'signed-by' /etc/apt/sources.list.d/trivy.list 2>/dev/null; then
     _GPG_TMP="$WORKDIR/trivy.gpg"
     if wget -qO "$_GPG_TMP" https://aquasecurity.github.io/trivy-repo/deb/public.key 2>/dev/null; then
-      sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg < "$_GPG_TMP" 2>/dev/null || true
+      sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg <"$_GPG_TMP" 2>/dev/null || true
     fi
     echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list >/dev/null
     ok "trivy (key migrated)"

--- a/lib/11-deploy-config.sh
+++ b/lib/11-deploy-config.sh
@@ -159,6 +159,16 @@ fi
 install -Dm755 "$REPO_FILES/dot-claude/claude-lens.sh" "$CLAUDE_DIR/claude-lens.sh" &&
   ok "claude-lens: statusline" || warn "claude-lens install failed"
 
+# ─── vexp-cli MCP server (global, stdio transport — starts on-demand per session) ───
+# Uses `vexp mcp` command directly — no mcp-server.cjs file needed
+if ! $VEXP_SKIP && ! $MINIMAL && command -v vexp &>/dev/null; then
+  jq '.mcpServers.vexp = {"command": "vexp", "args": ["mcp"]}' \
+    "$CLAUDE_DIR/settings.json" >"${WORKDIR}/_cc_settings.json" &&
+    mv "${WORKDIR}/_cc_settings.json" "$CLAUDE_DIR/settings.json" &&
+    ok "vexp: MCP server configured (stdio — vexp mcp)" ||
+    warn "vexp: MCP config injection failed"
+fi
+
 # ─── Skills ───
 # tool-discovery, security-ops, debug-protocol removed — replaced by better versions:
 #   tool-discovery → cli-tools (150 lines, full tool reference)

--- a/lib/12-plugins.sh
+++ b/lib/12-plugins.sh
@@ -21,8 +21,8 @@ elif ! claude auth status &>/dev/null 2>&1; then
   warn "Claude not authenticated — skipping plugins (run 'claude auth login' then re-run)"
 else
   # Register official marketplace if not already registered
-  claude plugin marketplace add anthropic/claude-plugins-official 2>/dev/null \
-    && ok "official marketplace" || ok "official marketplace (exists)"
+  claude plugin marketplace add anthropic/claude-plugins-official 2>/dev/null &&
+    ok "official marketplace" || ok "official marketplace (exists)"
 
   # Install plugins from official marketplace
   claude plugin install code-review 2>/dev/null && ok "code-review" || warn "code-review"
@@ -39,22 +39,22 @@ else
 
   # episodic-memory — semantic search over past Claude Code sessions (~200 tokens/session)
   # Free, MIT, no subscription. Local embeddings via @xenova/transformers (no API key needed).
-  claude plugin marketplace add obra/superpowers-marketplace 2>/dev/null \
-    && ok "superpowers marketplace" || ok "superpowers marketplace (exists)"
+  claude plugin marketplace add obra/superpowers-marketplace 2>/dev/null &&
+    ok "superpowers marketplace" || ok "superpowers marketplace (exists)"
   claude plugin install episodic-memory 2>/dev/null && ok "episodic-memory plugin" || warn "episodic-memory plugin"
 
   # cozempic plugin — context diagnose/treat MCP tools (diagnose_current, treat_session)
   # CLI (uv) provides the primary interface; plugin adds MCP tools for in-session diagnostics
   if ! $COZEMPIC_SKIP; then
-    claude plugin marketplace add Ruya-AI/cozempic 2>/dev/null \
-      && ok "cozempic marketplace" || ok "cozempic marketplace (exists)"
+    claude plugin marketplace add Ruya-AI/cozempic 2>/dev/null &&
+      ok "cozempic marketplace" || ok "cozempic marketplace (exists)"
     claude plugin install cozempic 2>/dev/null && ok "cozempic plugin" || warn "cozempic plugin"
   fi
 
   # claude-subconscious — Letta-based persistent cross-session memory agent
   if ! $LETTA_SKIP; then
-    claude plugin marketplace add letta-ai/claude-subconscious 2>/dev/null \
-      && ok "letta marketplace" || ok "letta marketplace (exists)"
+    claude plugin marketplace add letta-ai/claude-subconscious 2>/dev/null &&
+      ok "letta marketplace" || ok "letta marketplace (exists)"
     if claude plugin install claude-subconscious 2>/dev/null; then
       ok "claude-subconscious plugin"
 
@@ -62,9 +62,9 @@ else
       _SUBCON_DIR=$(jq -r '.plugins["claude-subconscious@claude-subconscious"][0].installPath // empty' \
         "$CLAUDE_DIR/plugins/installed_plugins.json" 2>/dev/null)
       if [[ -n "$_SUBCON_DIR" ]] && [[ -f "$_SUBCON_DIR/package.json" ]]; then
-        (cd "$_SUBCON_DIR" && npm install --silent 2>/dev/null) \
-          && ok "subconscious: node_modules installed" \
-          || warn "subconscious: npm install failed — hooks may not work"
+        (cd "$_SUBCON_DIR" && npm install --silent 2>/dev/null) &&
+          ok "subconscious: node_modules installed" ||
+          warn "subconscious: npm install failed — hooks may not work"
       fi
 
       # Patch Subconscious.af: override LLM + embedding to use self-hosted Letta infrastructure
@@ -79,8 +79,8 @@ else
       if [[ -f "$_SUBCON_AF" ]]; then
         # Patch LLM config: use ccflare billing proxy if available, else direct Anthropic
         # Check bun + proxy file (billing proxy was migrated from socat to Bun)
-        if ! $CCFLARE_SKIP && command -v bun &>/dev/null \
-            && [[ -f "$HOME/.config/letta/ccflare-billing-proxy.js" ]]; then
+        if ! $CCFLARE_SKIP && command -v bun &>/dev/null &&
+          [[ -f "$HOME/.config/letta/ccflare-billing-proxy.js" ]]; then
           _SUBCON_LLM_ENDPOINT="http://host.docker.internal:${CCFLARE_PROXY_PORT}"
         else
           _SUBCON_LLM_ENDPOINT="https://api.anthropic.com/v1"
@@ -93,10 +93,10 @@ else
           .agents[0].llm_config.provider_name = "anthropic" |
           .agents[0].llm_config.handle = "anthropic/claude-sonnet-4-6" |
           .agents[0].llm_config.context_window = 200000
-        ' "$_SUBCON_AF" > ${WORKDIR}/_subcon_af.json \
-          && mv ${WORKDIR}/_subcon_af.json "$_SUBCON_AF" \
-          && ok "subconscious: .af patched (LLM → claude-sonnet-4-6 via ${_SUBCON_LLM_ENDPOINT})" \
-          || warn "subconscious: .af LLM patch failed"
+        ' "$_SUBCON_AF" >${WORKDIR}/_subcon_af.json &&
+          mv ${WORKDIR}/_subcon_af.json "$_SUBCON_AF" &&
+          ok "subconscious: .af patched (LLM → claude-sonnet-4-6 via ${_SUBCON_LLM_ENDPOINT})" ||
+          warn "subconscious: .af LLM patch failed"
 
         # Patch embedding config: use host.docker.internal (Letta runs in Docker, must reach host Ollama)
         if ! $OLLAMA_SKIP && command -v ollama &>/dev/null; then
@@ -106,10 +106,10 @@ else
             .agents[0].embedding_config.embedding_model = "nomic-embed-text" |
             .agents[0].embedding_config.embedding_dim = 768 |
             .agents[0].embedding_config.handle = "ollama/nomic-embed-text"
-          ' "$_SUBCON_AF" > ${WORKDIR}/_subcon_af.json \
-            && mv ${WORKDIR}/_subcon_af.json "$_SUBCON_AF" \
-            && ok "subconscious: .af patched (embeddings → ollama/nomic-embed-text)" \
-            || warn "subconscious: .af embedding patch failed"
+          ' "$_SUBCON_AF" >${WORKDIR}/_subcon_af.json &&
+            mv ${WORKDIR}/_subcon_af.json "$_SUBCON_AF" &&
+            ok "subconscious: .af patched (embeddings → ollama/nomic-embed-text)" ||
+            warn "subconscious: .af embedding patch failed"
         fi
       else
         warn "subconscious: Subconscious.af not found — .af patching skipped"
@@ -117,10 +117,10 @@ else
 
       # Enable plugin in settings.json
       jq '.enabledPlugins["claude-subconscious@claude-subconscious"] = true' \
-        "$CLAUDE_DIR/settings.json" > ${WORKDIR}/_cc_settings.json \
-        && mv ${WORKDIR}/_cc_settings.json "$CLAUDE_DIR/settings.json" \
-        && ok "subconscious: enabled in settings.json" \
-        || warn "subconscious: settings.json update failed"
+        "$CLAUDE_DIR/settings.json" >${WORKDIR}/_cc_settings.json &&
+        mv ${WORKDIR}/_cc_settings.json "$CLAUDE_DIR/settings.json" &&
+        ok "subconscious: enabled in settings.json" ||
+        warn "subconscious: settings.json update failed"
     else
       warn "claude-subconscious plugin install failed"
     fi
@@ -128,4 +128,3 @@ else
 
 fi
 # ── end claude auth guard ──
-

--- a/lib/13-plugins-letta-ctrl.sh
+++ b/lib/13-plugins-letta-ctrl.sh
@@ -29,7 +29,7 @@ Type=simple
 ExecStart=${_BUN_BIN} run %h/.config/letta/letta-ctrl-server.js
 Environment="LETTA_CTRL_PORT=${LETTA_CTRL_PORT}"
 Environment="LETTA_BASE_URL=http://127.0.0.1:${LETTA_PORT}"
-$( [[ "$INSTALL_MODE" == "vps" ]] && echo 'Environment="LETTA_CTRL_TOKEN=disable"' )
+$([[ "$INSTALL_MODE" == "vps" ]] && echo 'Environment="LETTA_CTRL_TOKEN=disable"')
 Restart=on-failure
 RestartSec=5
 

--- a/test/session-review.bats
+++ b/test/session-review.bats
@@ -464,6 +464,58 @@ setup() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# VEXP-CLI INTEGRATION (ADR-030)
+# ════════════════════════════════════════════════════════════════════
+
+@test "VEXP: VEXP_SKIP variable defined in lib/02-cli.sh" {
+  grep -q 'VEXP_SKIP=false' "$REPO/lib/02-cli.sh"
+}
+
+@test "VEXP: --no-vexp flag in CLI parser" {
+  grep -q '\-\-no-vexp' "$REPO/lib/02-cli.sh"
+}
+
+@test "VEXP: --minimal sets VEXP_SKIP=true" {
+  grep -A6 '\-\-minimal' "$REPO/lib/02-cli.sh" | grep -q 'VEXP_SKIP=true'
+}
+
+@test "VEXP: vexp-cli install block in lib/07" {
+  grep -q 'bun install -g vexp-cli' "$REPO/lib/07-tools-python-js.sh"
+}
+
+@test "VEXP: install block guarded with VEXP_SKIP and MINIMAL" {
+  grep -q '! \$VEXP_SKIP && ! \$MINIMAL' "$REPO/lib/07-tools-python-js.sh"
+}
+
+@test "VEXP: install command uses ok/warn guard (set -e safe)" {
+  grep 'bun install -g vexp-cli' "$REPO/lib/07-tools-python-js.sh" | grep -qE '&&.*ok|warn'
+}
+
+@test "VEXP: vexp-core binary verification exists" {
+  grep -q 'vexp-core' "$REPO/lib/07-tools-python-js.sh"
+}
+
+@test "VEXP: MCP server config in lib/11 uses jq (not direct write)" {
+  grep -q 'jq.*mcpServers.*vexp' "$REPO/lib/11-deploy-config.sh"
+}
+
+@test "VEXP: MCP config uses vexp mcp command (stdio transport)" {
+  grep -q '"vexp".*"mcp"' "$REPO/lib/11-deploy-config.sh"
+}
+
+@test "VEXP: MCP config uses WORKDIR for temp file (not /tmp)" {
+  grep -A5 'mcpServers.*vexp' "$REPO/lib/11-deploy-config.sh" | grep -q 'WORKDIR'
+}
+
+@test "VEXP: MCP config injection guarded with ok/warn (set -e safe)" {
+  grep -A5 'mcpServers.*vexp' "$REPO/lib/11-deploy-config.sh" | grep -qE '&&.*ok|warn'
+}
+
+@test "ADR: decisions.md has ADR-031 (vexp-cli)" {
+  grep -q 'ADR-031.*vexp-cli.*stdio' "$REPO/docs/decisions.md"
+}
+
+# ════════════════════════════════════════════════════════════════════
 # BUILT SCRIPT INTEGRITY
 # ════════════════════════════════════════════════════════════════════
 

--- a/test/structure.bats
+++ b/test/structure.bats
@@ -125,3 +125,15 @@ setup() {
 @test "config/letta/letta-ctrl.html exists" {
   assert [ -f "$REPO/config/letta/letta-ctrl.html" ]
 }
+
+# ── vexp-cli integration ─────────────────────────────────────────────────
+
+@test "vexp-cli install block exists in lib/07" {
+  run grep -c "bun install -g vexp-cli" "$REPO/lib/07-tools-python-js.sh"
+  assert_success
+}
+
+@test "--no-vexp flag is recognized" {
+  run grep -c "\-\-no-vexp" "$REPO/lib/02-cli.sh"
+  assert_success
+}

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -40,7 +40,7 @@ fi
 # ║  from patrickjaja.github.io via sudo.                            ║
 # ╚══════════════════════════════════════════════════════════════════╝
 
-SCRIPT_VERSION="v3.20"
+SCRIPT_VERSION="v3.21"
 # ─── Phase checkpoint system for resume capability ───
 _PROGRESS_DIR="$HOME/.titan-progress"
 mkdir -p "$_PROGRESS_DIR" 2>/dev/null || true
@@ -135,6 +135,7 @@ OLLAMA_SKIP=false
 LETTA_CTRL_SKIP=false
 LETTA_CTRL_PORT=8284
 COZEMPIC_SKIP=false
+VEXP_SKIP=false
 FORCE_UPDATES=false
 MINIMAL=false
 
@@ -165,6 +166,7 @@ Options:
   --letta-ctrl-skip        Skip LettaCtrl GUI (default: install if Letta is installed)
   --letta-ctrl-port PORT   LettaCtrl server port (default: 8284)
   --no-cozempic            Skip cozempic install (context bloat cleaner)
+  --no-vexp                Skip vexp-cli install (context engine)
 
   --force-updates          Force upgrade all tools (uv, bun, cargo, go, binaries)
   --version                Show script version
@@ -303,6 +305,10 @@ while [[ $# -gt 0 ]]; do
       COZEMPIC_SKIP=true
       shift
       ;;
+    --no-vexp)
+      VEXP_SKIP=true
+      shift
+      ;;
     --force-updates)
       FORCE_UPDATES=true
       shift
@@ -317,6 +323,7 @@ while [[ $# -gt 0 ]]; do
       OLLAMA_SKIP=true
       COZEMPIC_SKIP=true
       LETTA_CTRL_SKIP=true
+      VEXP_SKIP=true
       shift
       ;;
     --secrets-file)
@@ -961,7 +968,8 @@ else
     if command -v cargo &>/dev/null; then
       ok "cargo installed: $(cargo --version)"
     else
-      fail "cargo install failed"; exit 1
+      fail "cargo install failed"
+      exit 1
     fi
   fi
   # Ensure cargo binaries are on PATH for the rest of this script (idempotent)
@@ -978,7 +986,8 @@ else
     if command -v uv &>/dev/null; then
       ok "uv installed: $(uv --version)"
     else
-      fail "uv install failed"; exit 1
+      fail "uv install failed"
+      exit 1
     fi
   fi
   # Ensure uv/uvx binaries are on PATH for the rest of this script
@@ -1222,6 +1231,22 @@ fi
 
 command -v gemini &>/dev/null && ok "gemini-cli (exists)" || { run_q bun install -g @google/gemini-cli && ok "gemini-cli" || warn "gemini-cli"; }
 command -v mmdc &>/dev/null && ok "mermaid-cli (exists)" || { run_q bun install -g @mermaid-js/mermaid-cli && ok "mermaid-cli" || warn "mermaid-cli"; }
+
+# vexp-cli — local-first context engine for AI coding agents (tree-sitter + dependency graph)
+# Uses optional deps (@vexp/core-linux-x64 etc.) for platform-specific Rust binary — no postinstall needed
+if ! $VEXP_SKIP && ! $MINIMAL; then
+  if bun pm ls -g 2>/dev/null | grep -q "vexp-cli"; then
+    ok "vexp-cli (exists)"
+  else
+    run_q bun install -g vexp-cli && ok "vexp-cli" || warn "vexp-cli (install manually: bun install -g vexp-cli)"
+  fi
+  # Verify vexp-core platform binary was installed via optional deps
+  if command -v vexp &>/dev/null && vexp version &>/dev/null; then
+    ok "vexp-core binary ($(vexp version 2>&1 | grep 'core:' | sed 's/.*: //' || echo 'ok'))"
+  elif bun pm ls -g 2>/dev/null | grep -q "vexp-cli"; then
+    warn "vexp-core binary missing — try: bun install -g @vexp/core-linux-$(uname -m | sed 's/x86_64/x64/;s/aarch64/arm64/')"
+  fi
+fi
 
 # playwright — browser automation and E2E testing
 # Ensure node is on PATH (mise shims may not be sourced in non-interactive context)
@@ -2145,7 +2170,7 @@ if ! command -v gcloud &>/dev/null; then
   # Download key to temp file first — piping to gpg --dearmor hangs if curl fails
   _GPG_TMP="$WORKDIR/gcloud.gpg"
   if curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg -o "$_GPG_TMP" 2>/dev/null; then
-    sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg < "$_GPG_TMP" 2>/dev/null || true
+    sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg <"$_GPG_TMP" 2>/dev/null || true
   fi
   echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" |
     sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
@@ -2157,7 +2182,7 @@ else ok "gcloud (exists)"; fi
 if ! command -v terraform &>/dev/null; then
   _GPG_TMP="$WORKDIR/hashicorp.gpg"
   if wget -qO "$_GPG_TMP" https://apt.releases.hashicorp.com/gpg 2>/dev/null; then
-    sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg < "$_GPG_TMP" 2>/dev/null || true
+    sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg <"$_GPG_TMP" 2>/dev/null || true
   fi
   echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list >/dev/null
   apt_update --force && sudo apt-get install -y -qq terraform packer &&
@@ -2194,7 +2219,7 @@ else ok "duckdb (exists)"; fi
 if ! command -v trivy &>/dev/null; then
   _GPG_TMP="$WORKDIR/trivy.gpg"
   if wget -qO "$_GPG_TMP" https://aquasecurity.github.io/trivy-repo/deb/public.key 2>/dev/null; then
-    sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg < "$_GPG_TMP" 2>/dev/null || true
+    sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg <"$_GPG_TMP" 2>/dev/null || true
   fi
   echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list >/dev/null
   apt_update --force && sudo apt-get install -y -qq trivy &&
@@ -2204,7 +2229,7 @@ else
   if ! grep -q 'signed-by' /etc/apt/sources.list.d/trivy.list 2>/dev/null; then
     _GPG_TMP="$WORKDIR/trivy.gpg"
     if wget -qO "$_GPG_TMP" https://aquasecurity.github.io/trivy-repo/deb/public.key 2>/dev/null; then
-      sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg < "$_GPG_TMP" 2>/dev/null || true
+      sudo gpg --dearmor -o /usr/share/keyrings/trivy.gpg <"$_GPG_TMP" 2>/dev/null || true
     fi
     echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list >/dev/null
     ok "trivy (key migrated)"
@@ -2537,6 +2562,16 @@ fi
 install -Dm755 "$REPO_FILES/dot-claude/claude-lens.sh" "$CLAUDE_DIR/claude-lens.sh" &&
   ok "claude-lens: statusline" || warn "claude-lens install failed"
 
+# ─── vexp-cli MCP server (global, stdio transport — starts on-demand per session) ───
+# Uses `vexp mcp` command directly — no mcp-server.cjs file needed
+if ! $VEXP_SKIP && ! $MINIMAL && command -v vexp &>/dev/null; then
+  jq '.mcpServers.vexp = {"command": "vexp", "args": ["mcp"]}' \
+    "$CLAUDE_DIR/settings.json" >"${WORKDIR}/_cc_settings.json" &&
+    mv "${WORKDIR}/_cc_settings.json" "$CLAUDE_DIR/settings.json" &&
+    ok "vexp: MCP server configured (stdio — vexp mcp)" ||
+    warn "vexp: MCP config injection failed"
+fi
+
 # ─── Skills ───
 # tool-discovery, security-ops, debug-protocol removed — replaced by better versions:
 #   tool-discovery → cli-tools (150 lines, full tool reference)
@@ -2864,8 +2899,8 @@ elif ! claude auth status &>/dev/null 2>&1; then
   warn "Claude not authenticated — skipping plugins (run 'claude auth login' then re-run)"
 else
   # Register official marketplace if not already registered
-  claude plugin marketplace add anthropic/claude-plugins-official 2>/dev/null \
-    && ok "official marketplace" || ok "official marketplace (exists)"
+  claude plugin marketplace add anthropic/claude-plugins-official 2>/dev/null &&
+    ok "official marketplace" || ok "official marketplace (exists)"
 
   # Install plugins from official marketplace
   claude plugin install code-review 2>/dev/null && ok "code-review" || warn "code-review"
@@ -2882,22 +2917,22 @@ else
 
   # episodic-memory — semantic search over past Claude Code sessions (~200 tokens/session)
   # Free, MIT, no subscription. Local embeddings via @xenova/transformers (no API key needed).
-  claude plugin marketplace add obra/superpowers-marketplace 2>/dev/null \
-    && ok "superpowers marketplace" || ok "superpowers marketplace (exists)"
+  claude plugin marketplace add obra/superpowers-marketplace 2>/dev/null &&
+    ok "superpowers marketplace" || ok "superpowers marketplace (exists)"
   claude plugin install episodic-memory 2>/dev/null && ok "episodic-memory plugin" || warn "episodic-memory plugin"
 
   # cozempic plugin — context diagnose/treat MCP tools (diagnose_current, treat_session)
   # CLI (uv) provides the primary interface; plugin adds MCP tools for in-session diagnostics
   if ! $COZEMPIC_SKIP; then
-    claude plugin marketplace add Ruya-AI/cozempic 2>/dev/null \
-      && ok "cozempic marketplace" || ok "cozempic marketplace (exists)"
+    claude plugin marketplace add Ruya-AI/cozempic 2>/dev/null &&
+      ok "cozempic marketplace" || ok "cozempic marketplace (exists)"
     claude plugin install cozempic 2>/dev/null && ok "cozempic plugin" || warn "cozempic plugin"
   fi
 
   # claude-subconscious — Letta-based persistent cross-session memory agent
   if ! $LETTA_SKIP; then
-    claude plugin marketplace add letta-ai/claude-subconscious 2>/dev/null \
-      && ok "letta marketplace" || ok "letta marketplace (exists)"
+    claude plugin marketplace add letta-ai/claude-subconscious 2>/dev/null &&
+      ok "letta marketplace" || ok "letta marketplace (exists)"
     if claude plugin install claude-subconscious 2>/dev/null; then
       ok "claude-subconscious plugin"
 
@@ -2905,9 +2940,9 @@ else
       _SUBCON_DIR=$(jq -r '.plugins["claude-subconscious@claude-subconscious"][0].installPath // empty' \
         "$CLAUDE_DIR/plugins/installed_plugins.json" 2>/dev/null)
       if [[ -n "$_SUBCON_DIR" ]] && [[ -f "$_SUBCON_DIR/package.json" ]]; then
-        (cd "$_SUBCON_DIR" && npm install --silent 2>/dev/null) \
-          && ok "subconscious: node_modules installed" \
-          || warn "subconscious: npm install failed — hooks may not work"
+        (cd "$_SUBCON_DIR" && npm install --silent 2>/dev/null) &&
+          ok "subconscious: node_modules installed" ||
+          warn "subconscious: npm install failed — hooks may not work"
       fi
 
       # Patch Subconscious.af: override LLM + embedding to use self-hosted Letta infrastructure
@@ -2922,8 +2957,8 @@ else
       if [[ -f "$_SUBCON_AF" ]]; then
         # Patch LLM config: use ccflare billing proxy if available, else direct Anthropic
         # Check bun + proxy file (billing proxy was migrated from socat to Bun)
-        if ! $CCFLARE_SKIP && command -v bun &>/dev/null \
-            && [[ -f "$HOME/.config/letta/ccflare-billing-proxy.js" ]]; then
+        if ! $CCFLARE_SKIP && command -v bun &>/dev/null &&
+          [[ -f "$HOME/.config/letta/ccflare-billing-proxy.js" ]]; then
           _SUBCON_LLM_ENDPOINT="http://host.docker.internal:${CCFLARE_PROXY_PORT}"
         else
           _SUBCON_LLM_ENDPOINT="https://api.anthropic.com/v1"
@@ -2936,10 +2971,10 @@ else
           .agents[0].llm_config.provider_name = "anthropic" |
           .agents[0].llm_config.handle = "anthropic/claude-sonnet-4-6" |
           .agents[0].llm_config.context_window = 200000
-        ' "$_SUBCON_AF" > ${WORKDIR}/_subcon_af.json \
-          && mv ${WORKDIR}/_subcon_af.json "$_SUBCON_AF" \
-          && ok "subconscious: .af patched (LLM → claude-sonnet-4-6 via ${_SUBCON_LLM_ENDPOINT})" \
-          || warn "subconscious: .af LLM patch failed"
+        ' "$_SUBCON_AF" >${WORKDIR}/_subcon_af.json &&
+          mv ${WORKDIR}/_subcon_af.json "$_SUBCON_AF" &&
+          ok "subconscious: .af patched (LLM → claude-sonnet-4-6 via ${_SUBCON_LLM_ENDPOINT})" ||
+          warn "subconscious: .af LLM patch failed"
 
         # Patch embedding config: use host.docker.internal (Letta runs in Docker, must reach host Ollama)
         if ! $OLLAMA_SKIP && command -v ollama &>/dev/null; then
@@ -2949,10 +2984,10 @@ else
             .agents[0].embedding_config.embedding_model = "nomic-embed-text" |
             .agents[0].embedding_config.embedding_dim = 768 |
             .agents[0].embedding_config.handle = "ollama/nomic-embed-text"
-          ' "$_SUBCON_AF" > ${WORKDIR}/_subcon_af.json \
-            && mv ${WORKDIR}/_subcon_af.json "$_SUBCON_AF" \
-            && ok "subconscious: .af patched (embeddings → ollama/nomic-embed-text)" \
-            || warn "subconscious: .af embedding patch failed"
+          ' "$_SUBCON_AF" >${WORKDIR}/_subcon_af.json &&
+            mv ${WORKDIR}/_subcon_af.json "$_SUBCON_AF" &&
+            ok "subconscious: .af patched (embeddings → ollama/nomic-embed-text)" ||
+            warn "subconscious: .af embedding patch failed"
         fi
       else
         warn "subconscious: Subconscious.af not found — .af patching skipped"
@@ -2960,10 +2995,10 @@ else
 
       # Enable plugin in settings.json
       jq '.enabledPlugins["claude-subconscious@claude-subconscious"] = true' \
-        "$CLAUDE_DIR/settings.json" > ${WORKDIR}/_cc_settings.json \
-        && mv ${WORKDIR}/_cc_settings.json "$CLAUDE_DIR/settings.json" \
-        && ok "subconscious: enabled in settings.json" \
-        || warn "subconscious: settings.json update failed"
+        "$CLAUDE_DIR/settings.json" >${WORKDIR}/_cc_settings.json &&
+        mv ${WORKDIR}/_cc_settings.json "$CLAUDE_DIR/settings.json" &&
+        ok "subconscious: enabled in settings.json" ||
+        warn "subconscious: settings.json update failed"
     else
       warn "claude-subconscious plugin install failed"
     fi
@@ -2971,7 +3006,6 @@ else
 
 fi
 # ── end claude auth guard ──
-
 # ─── LettaCtrl GUI — web dashboard for Letta management ───
 # NOTE: runs outside claude auth guard — letta-ctrl is standalone (no Claude auth needed)
 if $LETTA_SKIP || $LETTA_CTRL_SKIP; then
@@ -3003,7 +3037,7 @@ Type=simple
 ExecStart=${_BUN_BIN} run %h/.config/letta/letta-ctrl-server.js
 Environment="LETTA_CTRL_PORT=${LETTA_CTRL_PORT}"
 Environment="LETTA_BASE_URL=http://127.0.0.1:${LETTA_PORT}"
-$( [[ "$INSTALL_MODE" == "vps" ]] && echo 'Environment="LETTA_CTRL_TOKEN=disable"' )
+$([[ "$INSTALL_MODE" == "vps" ]] && echo 'Environment="LETTA_CTRL_TOKEN=disable"')
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary
- Install **vexp-cli** via `bun install -g` with platform-specific `@vexp/core-*` optional deps (x86_64 + ARM64)
- Auto-configure as **global MCP server** in `settings.json` using stdio transport (`vexp mcp`)
- New `--no-vexp` CLI flag; `--minimal` also skips vexp
- 12 regression tests in `test/session-review.bats` + 2 in `test/structure.bats`
- ADR-031 documenting design decisions (stdio over HTTP+SSE, user MCP servers preserved)
- Version bump: v3.20 → v3.21

## What is vexp-cli?
Local-first context engine for AI coding agents. Uses tree-sitter AST parsing + dependency graphs + skeleton context for ~65% token reduction. Ships 11 MCP tools (run_pipeline, get_context_capsule, get_impact_graph, etc.). Free tier: 2,000 nodes, 8 calls/day.

## Key Design Decisions
- **bun, not npm** — npm blocked by PreToolUse hook
- **`vexp mcp` command** — direct stdio, no `mcp-server.cjs` file needed
- **jq post-merge injection** — mcpServers NOT in TITAN_MANAGED_BLOCKS, preserves user-added MCP servers
- **No systemd service** — CC spawns/kills vexp on demand via stdio transport

## Test plan
- [x] `just check` — 190/190 tests pass (lint, fmt, build, test, smoke)
- [x] `gitleaks detect` — no secrets
- [x] Live install: `bun install -g vexp-cli` → verified `@vexp/core-linux-x64/bin/vexp-core` exists
- [x] `vexp version` → `CLI: 1.2.29, core: 1.0.0`
- [x] `vexp mcp --help` → confirms stdio transport
- [ ] E2E: full titan-setup.sh run on VPS (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)