### PR TITLE
fix: desktop mode HOME, hook stderr, subconscious /dev/tty

### DIFF
--- a/dot-claude/hooks/session-start.sh
+++ b/dot-claude/hooks/session-start.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # SessionStart hook — load previous session state and run maintenance
 # NOTE: no set -euo pipefail — hooks must not die on non-zero exits (ADR-015)
+# NOTE: all output to stdout (not stderr) — CC treats stderr as hook errors
 
 # ─── ntfy push notification helper ───
 _ntfy() {
@@ -20,18 +21,18 @@ HANDOFF="$HOME/.claude/memory/handoff.md"
 if [[ -f "$HANDOFF" ]]; then
   FILE_AGE=$(($(date +%s) - $(stat -c %Y "$HANDOFF" 2>/dev/null || echo 0)))
   if ((FILE_AGE < 86400)); then
-    echo "[Memory] Previous session handoff ($((FILE_AGE / 60))m ago):" >&2
-    head -30 "$HANDOFF" >&2
-    echo "---" >&2
+    echo "[Memory] Previous session handoff ($((FILE_AGE / 60))m ago):"
+    head -30 "$HANDOFF"
+    echo "---"
   fi
 fi
 
 # Remind about auto memory files
 MEMORY_COUNT=$(find "$HOME/.claude/projects/" -name "MEMORY.md" 2>/dev/null | wc -l)
 if ((MEMORY_COUNT > 0)); then
-  echo "[Memory] ${MEMORY_COUNT} project memory file(s) available." >&2
+  echo "[Memory] ${MEMORY_COUNT} project memory file(s) available."
 else
-  echo "[Memory] No project memories yet. Use /remember or write to auto memory directory." >&2
+  echo "[Memory] No project memories yet. Use /remember or write to auto memory directory."
 fi
 
 # ─── Maintenance: JSONL prune (cap at 30, delete >30 days old) ───
@@ -48,16 +49,16 @@ if [[ -f "$AUDIT_LOG" ]]; then
   AUDIT_SIZE=$(stat -c %s "$AUDIT_LOG" 2>/dev/null || echo 0)
   if ((AUDIT_SIZE > 10485760)); then
     mv "$AUDIT_LOG" "${AUDIT_LOG}.$(date +%s).bak"
-    echo "[Audit] Log rotated (was $((AUDIT_SIZE / 1048576))MB)" >&2
+    echo "[Audit] Log rotated (was $((AUDIT_SIZE / 1048576))MB)"
   fi
 fi
 
-# ─── Agent slots: show loaded agents (stderr = zero token cost) ───
+# ─── Agent slots: show loaded agents ───
 MANIFEST="$HOME/.claude/agent-stash/_loaded/.manifest"
 if [[ -f "$MANIFEST" ]] && [[ -s "$MANIFEST" ]]; then
-  echo "[Agents] Loaded slots:" >&2
+  echo "[Agents] Loaded slots:"
   while IFS=$'\t' read -r slot agent _ts; do
-    echo "  $slot: $agent" >&2
+    echo "  $slot: $agent"
   done <"$MANIFEST"
 fi
 
@@ -67,8 +68,8 @@ if command -v cc-patch-thinking >/dev/null 2>&1; then
   cc-patch-thinking --check 2>/dev/null || _patch_rc=$?
   case $_patch_rc in
     0) ;; # already patched
-    1) cc-patch-thinking 2>&1 | while read -r line; do echo "[Patch] $line" >&2; done ;;
-    2) echo "[Patch] cc-patch-thinking: unknown CC version — may need patcher update" >&2 ;;
+    1) cc-patch-thinking 2>&1 | while read -r line; do echo "[Patch] $line"; done ;;
+    2) echo "[Patch] cc-patch-thinking: unknown CC version — may need patcher update" ;;
   esac
 fi
 

--- a/lib/02-cli.sh
+++ b/lib/02-cli.sh
@@ -293,6 +293,22 @@ if [[ -z "$INSTALL_MODE" ]]; then
 fi
 echo -e "  Profile: ${GREEN}${INSTALL_MODE}${NC}\n"
 
+# ─── Desktop mode: fix HOME when running as root via sudo ───
+# sudo changes HOME to /root, but services/configs must go to the target user's home.
+# VPS mode handles this via re-exec (lib/03-vps-reexec.sh). Desktop mode needs this fix.
+if [[ "$INSTALL_MODE" == "desktop" && "$(id -u)" == "0" ]]; then
+  _TARGET_USER="${CLAUDE_USER:-${SUDO_USER:-}}"
+  if [[ -n "$_TARGET_USER" && "$_TARGET_USER" != "root" ]]; then
+    _TARGET_HOME=$(getent passwd "$_TARGET_USER" | cut -d: -f6)
+    if [[ -n "$_TARGET_HOME" && -d "$_TARGET_HOME" ]]; then
+      export HOME="$_TARGET_HOME"
+      # Add user's tool paths so mise/cargo/go/bun/uv binaries are found
+      export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.bun/bin:$HOME/go/bin:$PATH"
+      echo -e "  ${GREEN}✓${NC} HOME → $_TARGET_HOME (running as root, targeting $_TARGET_USER)"
+    fi
+  fi
+fi
+
 # ─── Claude Code version + autoupdate ───
 if [[ -z "$CC_VERSION" ]] && ! $CC_ASKED; then
   read -rp "  Claude Code version to install (blank = latest): " CC_VERSION || true

--- a/lib/07-tools-python-js.sh
+++ b/lib/07-tools-python-js.sh
@@ -231,7 +231,10 @@ fi
 if $CLAUDECODEUI_SKIP || $MINIMAL; then
   ok "claudecodeui (skipped)"
 else
-  _NODE_VER=$(node --version 2>/dev/null | sed 's/^v//' | cut -d. -f1 || echo "0")
+  # Check node version — also try mise shims (not on PATH when running as root)
+  _NODE_BIN=$(command -v node 2>/dev/null || echo "")
+  [[ -z "$_NODE_BIN" && -x "$HOME/.local/share/mise/shims/node" ]] && _NODE_BIN="$HOME/.local/share/mise/shims/node"
+  _NODE_VER=$("$_NODE_BIN" --version 2>/dev/null | sed 's/^v//' | cut -d. -f1 || echo "0")
   if [[ "$_NODE_VER" -lt 22 ]]; then
     warn "claudecodeui requires Node.js v22+ (found: v${_NODE_VER}) — skipping"
   else

--- a/lib/12-plugins.sh
+++ b/lib/12-plugins.sh
@@ -67,6 +67,15 @@ else
           warn "subconscious: npm install failed — hooks may not work"
       fi
 
+      # Patch /dev/tty crash: createWriteStream('/dev/tty') throws unhandled ENXIO in hook context
+      # (no terminal). Add .on("error") handler so the stream fails gracefully instead of crashing.
+      _SUBCON_SESS="$_SUBCON_DIR/scripts/session_start.ts"
+      if [[ -f "$_SUBCON_SESS" ]] && grep -q "createWriteStream('/dev/tty')" "$_SUBCON_SESS" 2>/dev/null; then
+        sed -i "s|tty = fs.createWriteStream('/dev/tty');|tty = fs.createWriteStream('/dev/tty'); tty.on('error', () => { tty = null; });|" "$_SUBCON_SESS" &&
+          ok "subconscious: patched /dev/tty crash (ENXIO in hook context)" ||
+          warn "subconscious: /dev/tty patch failed"
+      fi
+
       # Patch Subconscious.af: override LLM + embedding to use self-hosted Letta infrastructure
       # Default .af uses openai/text-embedding-3-small and zai/glm-5 (cloud only)
       _SUBCON_AF=""

--- a/test/session-review.bats
+++ b/test/session-review.bats
@@ -674,6 +674,25 @@ setup() {
 }
 
 # ════════════════════════════════════════════════════════════════════
+# DESKTOP MODE: HOME FIX FOR ROOT EXECUTION
+# ════════════════════════════════════════════════════════════════════
+
+@test "DESKTOP: HOME override for root execution uses CLAUDE_USER/SUDO_USER" {
+  grep -q 'INSTALL_MODE.*desktop.*id -u.*0' "$REPO/lib/02-cli.sh"
+  grep -q 'TARGET_USER.*CLAUDE_USER.*SUDO_USER' "$REPO/lib/02-cli.sh"
+  grep -q 'getent passwd.*TARGET_USER' "$REPO/lib/02-cli.sh"
+  grep -q 'export HOME=' "$REPO/lib/02-cli.sh"
+}
+
+@test "DESKTOP: PATH includes mise shims when running as root" {
+  grep -q 'mise/shims.*local/bin.*cargo/bin.*bun/bin.*go/bin' "$REPO/lib/02-cli.sh"
+}
+
+@test "DESKTOP: claudecodeui node check falls back to mise shims" {
+  grep -q 'mise/shims/node' "$REPO/lib/07-tools-python-js.sh"
+}
+
+# ════════════════════════════════════════════════════════════════════
 # BUILT SCRIPT INTEGRITY
 # ════════════════════════════════════════════════════════════════════
 

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -407,6 +407,22 @@ if [[ -z "$INSTALL_MODE" ]]; then
 fi
 echo -e "  Profile: ${GREEN}${INSTALL_MODE}${NC}\n"
 
+# ─── Desktop mode: fix HOME when running as root via sudo ───
+# sudo changes HOME to /root, but services/configs must go to the target user's home.
+# VPS mode handles this via re-exec (lib/03-vps-reexec.sh). Desktop mode needs this fix.
+if [[ "$INSTALL_MODE" == "desktop" && "$(id -u)" == "0" ]]; then
+  _TARGET_USER="${CLAUDE_USER:-${SUDO_USER:-}}"
+  if [[ -n "$_TARGET_USER" && "$_TARGET_USER" != "root" ]]; then
+    _TARGET_HOME=$(getent passwd "$_TARGET_USER" | cut -d: -f6)
+    if [[ -n "$_TARGET_HOME" && -d "$_TARGET_HOME" ]]; then
+      export HOME="$_TARGET_HOME"
+      # Add user's tool paths so mise/cargo/go/bun/uv binaries are found
+      export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.bun/bin:$HOME/go/bin:$PATH"
+      echo -e "  ${GREEN}✓${NC} HOME → $_TARGET_HOME (running as root, targeting $_TARGET_USER)"
+    fi
+  fi
+fi
+
 # ─── Claude Code version + autoupdate ───
 if [[ -z "$CC_VERSION" ]] && ! $CC_ASKED; then
   read -rp "  Claude Code version to install (blank = latest): " CC_VERSION || true
@@ -1369,7 +1385,10 @@ fi
 if $CLAUDECODEUI_SKIP || $MINIMAL; then
   ok "claudecodeui (skipped)"
 else
-  _NODE_VER=$(node --version 2>/dev/null | sed 's/^v//' | cut -d. -f1 || echo "0")
+  # Check node version — also try mise shims (not on PATH when running as root)
+  _NODE_BIN=$(command -v node 2>/dev/null || echo "")
+  [[ -z "$_NODE_BIN" && -x "$HOME/.local/share/mise/shims/node" ]] && _NODE_BIN="$HOME/.local/share/mise/shims/node"
+  _NODE_VER=$("$_NODE_BIN" --version 2>/dev/null | sed 's/^v//' | cut -d. -f1 || echo "0")
   if [[ "$_NODE_VER" -lt 22 ]]; then
     warn "claudecodeui requires Node.js v22+ (found: v${_NODE_VER}) — skipping"
   else
@@ -3017,6 +3036,15 @@ else
         (cd "$_SUBCON_DIR" && npm install --silent 2>/dev/null) &&
           ok "subconscious: node_modules installed" ||
           warn "subconscious: npm install failed — hooks may not work"
+      fi
+
+      # Patch /dev/tty crash: createWriteStream('/dev/tty') throws unhandled ENXIO in hook context
+      # (no terminal). Add .on("error") handler so the stream fails gracefully instead of crashing.
+      _SUBCON_SESS="$_SUBCON_DIR/scripts/session_start.ts"
+      if [[ -f "$_SUBCON_SESS" ]] && grep -q "createWriteStream('/dev/tty')" "$_SUBCON_SESS" 2>/dev/null; then
+        sed -i "s|tty = fs.createWriteStream('/dev/tty');|tty = fs.createWriteStream('/dev/tty'); tty.on('error', () => { tty = null; });|" "$_SUBCON_SESS" &&
+          ok "subconscious: patched /dev/tty crash (ENXIO in hook context)" ||
+          warn "subconscious: /dev/tty patch failed"
       fi
 
       # Patch Subconscious.af: override LLM + embedding to use self-hosted Letta infrastructure


### PR DESCRIPTION
## Summary
- **Desktop HOME fix**: `sudo bash titan-setup.sh` set HOME=/root — all services, configs, cargo/bun installs went to wrong location. Now overrides HOME to target user via `getent passwd` + prepends PATH with mise/cargo/bun/go shims
- **Node.js mise fallback**: claudecodeui skipped (found system node v18) — now checks `~/.local/share/mise/shims/node` as fallback
- **claude-subconscious /dev/tty crash**: plugin's `session_start.ts` calls `fs.createWriteStream('/dev/tty')` which throws unhandled ENXIO in hook context. Titan now patches with `.on('error')` handler after plugin install
- **Hook stderr → stdout**: CC 2.1.81 treats any stderr from hooks as "hook error". Removed all `>&2` from session-start.sh

## Files Changed
| File | What |
|------|------|
| `lib/02-cli.sh` | HOME + PATH override for desktop root execution |
| `lib/07-tools-python-js.sh` | Node.js mise shim fallback for claudecodeui |
| `lib/12-plugins.sh` | claude-subconscious /dev/tty patch after install |
| `dot-claude/hooks/session-start.sh` | All `>&2` → stdout |
| `test/session-review.bats` | 3 regression tests |
| `titan-setup.sh` | Rebuilt from fragments |

## Test plan
- [x] `just build && just test` — 233/233 pass
- [x] `gitleaks detect` — no leaks
- [x] Live desktop test via `sudo bash titan-setup.sh --mode desktop --name sutanu --claude-user sutanu`
  - HOME correctly set to /home/sutanu
  - All services in ~/.config/systemd/user/ (not /root/)
  - claudecodeui installed (mise node v22 found)
  - Letta service uses Type=oneshot (correct pattern)
- [x] New Claude session: zero hook errors after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)