### PR TITLE
fix: tmux wrapper uses absolute path (sudo CWD fix)

### DIFF
--- a/lib/03-vps-reexec.sh
+++ b/lib/03-vps-reexec.sh
@@ -108,7 +108,7 @@ if [[ -z "${TMUX:-}" ]] && [[ "${TITAN_TMUX:-}" != "1" ]]; then
     _TMUX_LOG="/tmp/titan-setup-$(date +%Y%m%d-%H%M%S).log"
     _TMUX_WRAPPER=$(mktemp /tmp/titan-tmux-XXXXXX.sh)
     {
-      printf 'TITAN_TMUX=1 bash %q' "$0"
+      printf 'TITAN_TMUX=1 bash %q' "$(readlink -f "$0")"
       if [[ ${#_ORIG_ARGS[@]} -gt 0 ]]; then
         printf ' %q' "${_ORIG_ARGS[@]}"
       fi

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -548,7 +548,7 @@ if [[ -z "${TMUX:-}" ]] && [[ "${TITAN_TMUX:-}" != "1" ]]; then
     _TMUX_LOG="/tmp/titan-setup-$(date +%Y%m%d-%H%M%S).log"
     _TMUX_WRAPPER=$(mktemp /tmp/titan-tmux-XXXXXX.sh)
     {
-      printf 'TITAN_TMUX=1 bash %q' "$0"
+      printf 'TITAN_TMUX=1 bash %q' "$(readlink -f "$0")"
       if [[ ${#_ORIG_ARGS[@]} -gt 0 ]]; then
         printf ' %q' "${_ORIG_ARGS[@]}"
       fi


### PR DESCRIPTION
## Summary
- tmux wrapper used `$0` (relative `./titan-setup.sh`) — fails when sudo changes CWD to /root
- Fix: `readlink -f "$0"` resolves to absolute path before writing wrapper script

## Reproduce
```bash
cd ~/claude-titan-setup
sudo bash titan-setup.sh --mode desktop --name sutanu
# → tmux session dies: "bash: ./titan-setup.sh: No such file or directory"
```

## Test plan
- [x] `just build && just test` — 233/233 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)