### PR TITLE
fix: canonicalize $0 at startup (universal path fix)

### DIFF
--- a/lib/00-header.sh
+++ b/lib/00-header.sh
@@ -20,6 +20,18 @@ if [[ ! -f "$0" ]]; then
 fi
 # ────────────────────────────────────────────────────────────────────────────
 
+# ─── Canonicalize $0 to absolute path ──────────────────────────────────────
+# After this point $0 is guaranteed absolute. Needed because:
+#   - tmux re-launch writes $0 into a wrapper script (CWD changes under sudo)
+#   - VPS re-exec copies $0 to /tmp (needs readable path)
+#   - readlink -f resolves ./relative, symlinks, and /tmp paths uniformly
+_SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")"
+if [[ "$_SCRIPT_PATH" != "$0" && -f "$_SCRIPT_PATH" ]]; then
+  # Re-exec with absolute path so all downstream $0 references are stable
+  exec bash "$_SCRIPT_PATH" "$@"
+fi
+# ────────────────────────────────────────────────────────────────────────────
+
 # ╔══════════════════════════════════════════════════════════════════╗
 # ║  TITAN SETUP — Single Source of Truth                           ║
 # ║  Fresh Ubuntu → fully armed Claude Code workstation             ║

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -20,6 +20,18 @@ if [[ ! -f "$0" ]]; then
 fi
 # ────────────────────────────────────────────────────────────────────────────
 
+# ─── Canonicalize $0 to absolute path ──────────────────────────────────────
+# After this point $0 is guaranteed absolute. Needed because:
+#   - tmux re-launch writes $0 into a wrapper script (CWD changes under sudo)
+#   - VPS re-exec copies $0 to /tmp (needs readable path)
+#   - readlink -f resolves ./relative, symlinks, and /tmp paths uniformly
+_SCRIPT_PATH="$(readlink -f "$0" 2>/dev/null || realpath "$0" 2>/dev/null || echo "$0")"
+if [[ "$_SCRIPT_PATH" != "$0" && -f "$_SCRIPT_PATH" ]]; then
+  # Re-exec with absolute path so all downstream $0 references are stable
+  exec bash "$_SCRIPT_PATH" "$@"
+fi
+# ────────────────────────────────────────────────────────────────────────────
+
 # ╔══════════════════════════════════════════════════════════════════╗
 # ║  TITAN SETUP — Single Source of Truth                           ║
 # ║  Fresh Ubuntu → fully armed Claude Code workstation             ║


### PR DESCRIPTION
## Summary
Supersedes the per-site `readlink -f` fix from PR #59. Instead of patching individual `$0` references, resolve once at startup via `exec bash "$(readlink -f "$0")" "$@"`.

After this, `$0` is guaranteed absolute everywhere — tmux wrapper, VPS re-exec, all downstream code just uses `$0` directly.

### All invocation patterns now work:
| Pattern | Before | After |
|---------|--------|-------|
| `bash <(curl ...)` | self-materialize (existing) | same |
| `cd repo && bash ./script.sh` | tmux fails (relative path) | exec resolves to absolute |
| `sudo bash /tmp/titan-setup.sh` | works (already absolute) | same |
| `sudo -E bash titan-setup.sh` | tmux fails | exec resolves |
| VPS re-exec | works | same |

## Test plan
- [x] `just build && just test` — 233/233 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)