### PR TITLE
fix(plugins): patch hooks.json to hardcode CLAUDE_PLUGIN_ROOT path

### DIFF
--- a/lib/12-plugins.sh
+++ b/lib/12-plugins.sh
@@ -67,6 +67,18 @@ else
           warn "subconscious: npm install failed — hooks may not work"
       fi
 
+      # Patch hooks.json: replace ${CLAUDE_PLUGIN_ROOT} with hardcoded absolute path.
+      # CC does not inject CLAUDE_PLUGIN_ROOT into hook subprocesses — empty string causes
+      # "Cannot find module '/hooks/...'" (MODULE_NOT_FOUND) on every hook invocation.
+      # Guard: only apply when literal '${CLAUDE_PLUGIN_ROOT}' is still present (idempotent).
+      _SUBCON_HOOKS="$_SUBCON_DIR/hooks/hooks.json"
+      if [[ -n "$_SUBCON_DIR" ]] && [[ -f "$_SUBCON_HOOKS" ]] &&
+          grep -q '\${CLAUDE_PLUGIN_ROOT}' "$_SUBCON_HOOKS" 2>/dev/null; then
+        sed -i "s|\${CLAUDE_PLUGIN_ROOT}|${_SUBCON_DIR}|g" "$_SUBCON_HOOKS" &&
+          ok "subconscious: patched hooks.json (CLAUDE_PLUGIN_ROOT → hardcoded path)" ||
+          warn "subconscious: hooks.json CLAUDE_PLUGIN_ROOT patch failed"
+      fi
+
       # Patch /dev/tty crash: createWriteStream('/dev/tty') throws unhandled ENXIO in hook context
       # (no terminal). Add .on("error") handler so the stream fails gracefully instead of crashing.
       _SUBCON_SESS="$_SUBCON_DIR/scripts/session_start.ts"

--- a/test/session-review.bats
+++ b/test/session-review.bats
@@ -842,3 +842,24 @@ setup() {
 @test "ROT: assembled titan-setup.sh includes password rotation logic" {
   grep -q '_RUNNING_PASS=$(docker inspect letta-server' "$REPO/titan-setup.sh"
 }
+
+
+# ── CLAUDE_PLUGIN_ROOT injection fix (issue #67, 2026-04-01) ──
+@test "I67: lib/12 patches hooks.json to replace CLAUDE_PLUGIN_ROOT with hardcoded path" {
+  grep -q 'CLAUDE_PLUGIN_ROOT.*hardcoded\|hardcoded.*CLAUDE_PLUGIN_ROOT\|CLAUDE_PLUGIN_ROOT.*hardcoded path\|hardcoded path' \
+    "$REPO/lib/12-plugins.sh"
+}
+
+@test "I67: lib/12 hooks.json patch uses sed with _SUBCON_DIR substitution" {
+  grep -q 'sed.*CLAUDE_PLUGIN_ROOT.*_SUBCON_DIR\|sed.*_SUBCON_DIR.*CLAUDE_PLUGIN_ROOT' \
+    "$REPO/lib/12-plugins.sh"
+}
+
+@test "I67: lib/12 hooks.json patch is idempotent (guarded by grep check)" {
+  grep -q "grep.*CLAUDE_PLUGIN_ROOT.*_SUBCON_HOOKS\|grep -q.*CLAUDE_PLUGIN_ROOT.*_SUBCON_HOOKS" \
+    "$REPO/lib/12-plugins.sh"
+}
+
+@test "I67: assembled titan-setup.sh includes CLAUDE_PLUGIN_ROOT hooks.json patch" {
+  grep -q 'CLAUDE_PLUGIN_ROOT.*hooks.json\|hooks.json.*CLAUDE_PLUGIN_ROOT' "$REPO/titan-setup.sh"
+}

--- a/titan-setup.sh
+++ b/titan-setup.sh
@@ -3078,6 +3078,18 @@ else
           warn "subconscious: npm install failed — hooks may not work"
       fi
 
+      # Patch hooks.json: replace ${CLAUDE_PLUGIN_ROOT} with hardcoded absolute path.
+      # CC does not inject CLAUDE_PLUGIN_ROOT into hook subprocesses — empty string causes
+      # "Cannot find module '/hooks/...'" (MODULE_NOT_FOUND) on every hook invocation.
+      # Guard: only apply when literal '${CLAUDE_PLUGIN_ROOT}' is still present (idempotent).
+      _SUBCON_HOOKS="$_SUBCON_DIR/hooks/hooks.json"
+      if [[ -n "$_SUBCON_DIR" ]] && [[ -f "$_SUBCON_HOOKS" ]] &&
+          grep -q '\${CLAUDE_PLUGIN_ROOT}' "$_SUBCON_HOOKS" 2>/dev/null; then
+        sed -i "s|\${CLAUDE_PLUGIN_ROOT}|${_SUBCON_DIR}|g" "$_SUBCON_HOOKS" &&
+          ok "subconscious: patched hooks.json (CLAUDE_PLUGIN_ROOT → hardcoded path)" ||
+          warn "subconscious: hooks.json CLAUDE_PLUGIN_ROOT patch failed"
+      fi
+
       # Patch /dev/tty crash: createWriteStream('/dev/tty') throws unhandled ENXIO in hook context
       # (no terminal). Add .on("error") handler so the stream fails gracefully instead of crashing.
       _SUBCON_SESS="$_SUBCON_DIR/scripts/session_start.ts"


### PR DESCRIPTION
CC does not inject CLAUDE_PLUGIN_ROOT into hook subprocess environments, causing every plugin hook to fail with MODULE_NOT_FOUND (empty string resolves to '/hooks/silent-npx.cjs' which doesn't exist).

After installing claude-subconscious, sed-patch hooks.json to replace all \${CLAUDE_PLUGIN_ROOT} references with the plugin's absolute install path. The patch is idempotent — guarded by checking that the literal \${CLAUDE_PLUGIN_ROOT} string is still present before applying.

Adds 4 regression tests in test/session-review.bats (I67 suite).

Fixes #67